### PR TITLE
Fix compound unit token error in RF_Auras / RF_AuraDisplay (closes #121, #122)

### DIFF
--- a/Modules/Mainline/Unitframes/RF_AuraDisplay.lua
+++ b/Modules/Mainline/Unitframes/RF_AuraDisplay.lua
@@ -12,6 +12,22 @@ local function GetDefensiveSize()
     return (raid and raid.centerDefensiveSize) or 60
 end
 
+-- C_UnitAuras.GetAuraSlots errors on any compound unit token (e.g.
+-- boss1targetpet, partypet1target). Compact party/raid frames legitimately
+-- only ever display these simple tokens; anything else is skipped rather
+-- than passed through.
+local function isSimpleRaidUnit(unit)
+    if not unit then
+        return false
+    end
+    return unit == "player"
+        or unit == "pet"
+        or unit:match("^party%d+$") ~= nil
+        or unit:match("^partypet%d+$") ~= nil
+        or unit:match("^raid%d+$") ~= nil
+        or unit:match("^raidpet%d+$") ~= nil
+end
+
 local DEFENSIVE_POINTS = {
     CENTER = true,
     LEFT = true,
@@ -687,7 +703,7 @@ function RF_AuraDisplay:OnInitialize()
         PositionAnchors(frame, data)
 
         local unit = frame.displayedUnit or frame.unit
-        if not unit or unit:match("target") then
+        if not isSimpleRaidUnit(unit) then
             return
         end
 

--- a/Modules/Mainline/Unitframes/RF_Auras.lua
+++ b/Modules/Mainline/Unitframes/RF_Auras.lua
@@ -1,5 +1,22 @@
 local RF_Auras = mUI:NewModule("mUI.Modules.Unitframes.RF_Auras", "AceHook-3.0")
 
+-- AuraUtil.ForEachAura -> C_UnitAuras.GetAuraSlots errors on any compound
+-- unit token (e.g. boss1targetpet, partypet1target). Compact party/raid
+-- frames legitimately only ever display these simple tokens; anything else
+-- (compound forms, boss/arena/nameplate, vehicle re-bindings from other
+-- addons, etc.) is skipped rather than passed through.
+local function isSimpleRaidUnit(unit)
+    if not unit then
+        return false
+    end
+    return unit == "player"
+        or unit == "pet"
+        or unit:match("^party%d+$") ~= nil
+        or unit:match("^partypet%d+$") ~= nil
+        or unit:match("^raid%d+$") ~= nil
+        or unit:match("^raidpet%d+$") ~= nil
+end
+
 function RF_Auras:OnInitialize()
     local LCG = LibStub("LibCustomGlow-1.0")
     local GLOW_KEY = "mUI_RF_Dispel"
@@ -18,12 +35,7 @@ function RF_Auras:OnInitialize()
         end
 
         local unit = frame.displayedUnit or frame.unit
-        -- ForEachAura rejects compound tokens (e.g. boss1targetpet). The
-        -- only compound tokens that reach raid/party frames contain "target";
-        -- pet tokens like "raidpet1" are fine. UnitTokenFromGUID would
-        -- normally resolve them but returns secret values under taint, so
-        -- simple substring filtering is the safe path.
-        if not unit or unit:match("target") then
+        if not isSimpleRaidUnit(unit) then
             return
         end
 


### PR DESCRIPTION
Both #121 and #122 are the same bug `bad argument #1 to '?' (Compound unit tokens ... are not allowed)` out of `C_UnitAuras.GetAuraSlots`, mostly hitting people in 11.x world content (the "Ours Once More!" delve in Zul Aman comes up in both reports).

The current guard in `RF_Auras.lua` skips tokens containing `"target"` on the assumption that's the only compound form that can reach a raid frame. That's mostly true but not always under vehicle re-bindings, scenario frames, and a few addon interactions, compound tokens without `"target"` in the name still slip past it and hit the API.

Switched the guard from a substring deny-list to a small allow-list of the simple unit tokens that legitimately appear on compact party/raid frames: `player`, `pet`, `partyN`, `partypetN`, `raidN`, `raidpetN`. Anything outside that list (compound forms, boss/arena/nameplate, weird stuff from other addons) gets skipped instead of crashing.

Same loose guard existed in `RF_AuraDisplay.lua` so I patched it there too with the same helper.

Closes #121, closes #122